### PR TITLE
about rowtotal function

### DIFF
--- a/2_delivery_care.do
+++ b/2_delivery_care.do
@@ -27,8 +27,10 @@ gen c_facdel = .
 	 }
 
 	/* do consider as skilled if contain words in the first group but don't contain any words in the second group */
+	
+	drop sba_skill
 
-	replace sba_skill = rowtotal(m3a-m3m),mi
+	egen sba_skill = rowtotal(m3a-m3m),mi
 
 	*c_hospdel: child born in hospital of births in last 2 years
 


### PR DESCRIPTION
replace can not work with rowtotal function in my stata. I got warning below:

`.         replace sba_skill = rowtotal(m3a-m3m),mi
unknown function rowtotal()
`

Could you let me know how did it work on your end? Is this version issue?